### PR TITLE
Fix h5py save error

### DIFF
--- a/kapre/time_frequency.py
+++ b/kapre/time_frequency.py
@@ -167,8 +167,8 @@ class Spectrogram(Layer):
                                           self.n_hop)
 
         dft_real_kernels, dft_imag_kernels = backend.get_stft_kernels(self.n_dft)
-        self.dft_real_kernels = K.variable(dft_real_kernels, dtype=K.floatx())
-        self.dft_imag_kernels = K.variable(dft_imag_kernels, dtype=K.floatx())
+        self.dft_real_kernels = K.variable(dft_real_kernels, dtype=K.floatx(), name="real_kernels")
+        self.dft_imag_kernels = K.variable(dft_imag_kernels, dtype=K.floatx(), name="imag_kernels")
         # kernels shapes: (filter_length, 1, input_dim, nb_filter)?
         if self.trainable_kernel:
             self.trainable_weights.append(self.dft_real_kernels)


### PR DESCRIPTION
Trying to use `model.save()` on a model containing the `Spetrogram` layer was failing with:
```
  File "/usr/local/lib/python2.7/dist-packages/keras/engine/topology.py", line 2434, in save
    save_model(self, filepath, overwrite, include_optimizer)
  File "/usr/local/lib/python2.7/dist-packages/keras/models.py", line 110, in save_model
    topology.save_weights_to_hdf5_group(model_weights_group, model_layers)
  File "/usr/local/lib/python2.7/dist-packages/keras/engine/topology.py", line 2726, in save_weights_to_hdf5_group
    dtype=val.dtype)
  File "/usr/local/lib/python2.7/dist-packages/h5py/_hl/group.py", line 111, in create_dataset
    self[name] = dset
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper (/tmp/pip-nCYoKW-build/h5py/_objects.c:2840)
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper (/tmp/pip-nCYoKW-build/h5py/_objects.c:2798)
  File "/usr/local/lib/python2.7/dist-packages/h5py/_hl/group.py", line 276, in __setitem__
    h5o.link(obj.id, self.id, name, lcpl=lcpl, lapl=self._lapl)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper (/tmp/pip-nCYoKW-build/h5py/_objects.c:2840)
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper (/tmp/pip-nCYoKW-build/h5py/_objects.c:2798)
  File "h5py/h5o.pyx", line 202, in h5py.h5o.link (/tmp/pip-nCYoKW-build/h5py/h5o.c:3895)
RuntimeError: Unable to create link (Name already exists)
```

The error is caused by the Keras variables used in the layer, which by default get the name "variable". This works fine if only one such variable is used in a layer but becomes a problem in `Spectrogram` because the variables constructed for `self.dft_real_kernels` and `self.dft_imag_kernels` have the same default name.