### PR TITLE
Python 3 compatibility

### DIFF
--- a/kapre/backend.py
+++ b/kapre/backend.py
@@ -10,6 +10,8 @@ from keras import backend as K
 import numpy as np
 from librosa.core.time_frequency import fft_frequencies, mel_frequencies
 import librosa
+# Forward compatability to replace xrange
+from builtins import range
 
 TOL = 1e-5
 EPS = 1e-7
@@ -173,16 +175,14 @@ def get_stft_kernels(n_dft, keras_ver='new'):
     assert n_dft > 1 and ((n_dft & (n_dft - 1)) == 0), \
         ('n_dft should be > 1 and power of 2, but n_dft == %d' % n_dft)
 
-    nb_filter = n_dft / 2 + 1
+    nb_filter = int(n_dft / 2 + 1)
     dtype = K.floatx()
 
     # prepare DFT filters
     timesteps = range(n_dft)
-    w_ks = [(2 * np.pi * k) / float(n_dft) for k in xrange(n_dft)]
-    dft_real_kernels = np.array([[np.cos(w_k * n) for n in timesteps]
-                                 for w_k in w_ks])
-    dft_imag_kernels = np.array([[np.sin(w_k * n) for n in timesteps]
-                                 for w_k in w_ks])
+    w_ks = [(2 * np.pi * k) / float(n_dft) for k in range(n_dft)]
+    dft_real_kernels = np.array([[np.cos(w_k * n) for n in timesteps] for w_k in w_ks])
+    dft_imag_kernels = np.array([[np.sin(w_k * n) for n in timesteps] for w_k in w_ks])
 
     # windowing DFT filters
     dft_window = _hann(n_dft, sym=False)

--- a/kapre/datasets.py
+++ b/kapre/datasets.py
@@ -1,5 +1,5 @@
 import os
-import utils_datasets
+from . import utils_datasets
 import librosa
 import numpy as np
 

--- a/kapre/stft.py
+++ b/kapre/stft.py
@@ -105,7 +105,8 @@ class Stft(Layer):
             self.dim_ordering = dim_ordering
 
         self.n_fft = n_fft
-        self.n_freq = (n_fft / 2) + 1
+        assert n_fft % 2 == 0
+        self.n_freq = int((n_fft / 2) + 1)
         self.n_hop = n_hop
         # self.border_mode = 'same'
         self.power_stft = float(power_stft)

--- a/kapre/time_frequency.py
+++ b/kapre/time_frequency.py
@@ -157,7 +157,8 @@ class Spectrogram(Layer):
             self.dim_ordering = dim_ordering
 
         self.n_dft = n_dft
-        self.n_filter = (n_dft / 2) + 1
+        assert n_dft % 2 == 0
+        self.n_filter = int(n_dft / 2) + 1
         self.trainable_kernel = trainable_kernel
         self.n_hop = n_hop
         self.padding = 'same'


### PR DESCRIPTION
1. xrange removed in favor of range (xrange == range with a new import in Python 2)
2. Explicit int() for in/out size calculation for Python 3. (Implicit C-like integer division in Python 2)