### PR TITLE
Make Melspectrogram independent of librosa version

### DIFF
--- a/kapre/time_frequency.py
+++ b/kapre/time_frequency.py
@@ -277,7 +277,7 @@ class Melspectrogram(Spectrogram):
         return_decibel_melgram=False,
         trainable_fb=False,
         htk=False,
-        norm=1,
+        norm='slaney',
         **kwargs,
     ):
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'numpy >= 1.8.0',
-        'librosa >= 0.5',
+        'librosa >= 0.7.2',
         'tensorflow >= 1.15',
     ],
     keywords='audio music deep learning keras',


### PR DESCRIPTION
Librosa v0.8 changed its interpretation of `norm=1` (https://github.com/librosa/librosa/issues/1030). This fix restores the behaviour of v0.7.2 and is compatible with both librosa v0.8 and v0.7.2 (but fails with v0.7.1 and earlier)