### PR TITLE
docs: Fix simple typo, legnth -> length

### DIFF
--- a/kapre/composed.py
+++ b/kapre/composed.py
@@ -36,7 +36,7 @@ def get_stft_magnitude_layer(
         hop_length (int): hop length of `STFT`
         window_fn (function or `None`): windowing function of `STFT`.
             Defaults to `None`, which would follow tf.signal.stft default (hann window at the moment)
-        pad_begin (bool): Whether to pad with zeros along time axis (legnth: win_length - hop_length). Defaults to `False`.
+        pad_begin (bool): Whether to pad with zeros along time axis (length: win_length - hop_length). Defaults to `False`.
         pad_end (bool): whether to pad the input signal at the end in `STFT`.
         return_decibel (bool): whether to apply decibel scaling at the end
         db_amin (float): noise floor of decibel scaling input. See `MagnitudeToDecibel` for more details.
@@ -145,7 +145,7 @@ def get_melspectrogram_layer(
         hop_length (int): hop length of `STFT`
         window_fn (function or `None`): windowing function of `STFT`.
             Defaults to `None`, which would follow tf.signal.stft default (hann window at the moment)
-        pad_begin (bool): Whether to pad with zeros along time axis (legnth: win_length - hop_length). Defaults to `False`.
+        pad_begin (bool): Whether to pad with zeros along time axis (length: win_length - hop_length). Defaults to `False`.
         pad_end (bool): whether to pad the input signal at the end in `STFT`.
         sample_rate (int): sample rate of the input audio
         n_mels (int): number of mel bins in the mel filterbank
@@ -267,7 +267,7 @@ def get_log_frequency_spectrogram_layer(
         hop_length (int): hop length of `STFT`
         window_fn (function or `None`): windowing function of `STFT`.
             Defaults to `None`, which would follow tf.signal.stft default (hann window at the moment)
-        pad_begin(bool): Whether to pad with zeros along time axis (legnth: win_length - hop_length). Defaults to `False`.
+        pad_begin(bool): Whether to pad with zeros along time axis (length: win_length - hop_length). Defaults to `False`.
         pad_end (bool): whether to pad the input signal at the end in `STFT`.
         sample_rate (int): sample rate of the input audio
         log_n_bins (int): number of the bins in the log-frequency filterbank
@@ -495,7 +495,7 @@ def get_stft_mag_phase(
         hop_length (int): hop length of `STFT`
         window_fn (function or `None`): windowing function of `STFT`.
             Defaults to `None`, which would follow tf.signal.stft default (hann window at the moment)
-        pad_begin(bool): Whether to pad with zeros along time axis (legnth: win_length - hop_length). Defaults to `False`.
+        pad_begin(bool): Whether to pad with zeros along time axis (length: win_length - hop_length). Defaults to `False`.
         pad_end (bool): whether to pad the input signal at the end in `STFT`.
         return_decibel (bool): whether to apply decibel scaling at the end
         db_amin (float): noise floor of decibel scaling input. See `MagnitudeToDecibel` for more details.

--- a/kapre/time_frequency.py
+++ b/kapre/time_frequency.py
@@ -69,7 +69,7 @@ class STFT(Layer):
         win_length (int or None): Window length in sample. Defaults to `n_fft`.
         hop_length (int or None): Hop length in sample between analysis windows. Defaults to `n_fft // 4` following Librosa.
         window_fn (function or None): A function that returns a 1D tensor window that is used in analysis. Defaults to `tf.signal.hann_window`
-        pad_begin (bool): Whether to pad with zeros along time axis (legnth: win_length - hop_length). Defaults to `False`.
+        pad_begin (bool): Whether to pad with zeros along time axis (length: win_length - hop_length). Defaults to `False`.
         pad_end (bool): Whether to pad with zeros at the finishing end of the signal.
         input_data_format (str): the audio data format of input waveform batch.
             `'channels_last'` if it's `(batch, time, channels)` and


### PR DESCRIPTION
There is a small typo in kapre/composed.py, kapre/time_frequency.py.

Should read `length` rather than `legnth`.

