### PR TITLE
Added parallel STFT implementation

### DIFF
--- a/kapre/composed.py
+++ b/kapre/composed.py
@@ -44,6 +44,7 @@ def get_stft_magnitude_layer(
     input_data_format='default',
     output_data_format='default',
     name='stft_magnitude',
+    use_parallel_stft=False,
 ):
     """A function that returns a stft magnitude layer.
     The layer is a `keras.Sequential` model consists of `STFT`, `Magnitude`, and optionally `MagnitudeToDecibel`.
@@ -121,6 +122,7 @@ def get_stft_magnitude_layer(
         pad_end=pad_end,
         input_data_format=input_data_format,
         output_data_format=output_data_format,
+        use_parallel_stft=use_parallel_stft,
     )
 
     stft_to_stftm = Magnitude()
@@ -156,6 +158,7 @@ def get_melspectrogram_layer(
     input_data_format='default',
     output_data_format='default',
     name='melspectrogram',
+    use_parallel_stft=False
 ):
     """A function that returns a melspectrogram layer, which is a `keras.Sequential` model consists of
     `STFT`, `Magnitude`, `ApplyFilterbank(_mel_filterbank)`, and optionally `MagnitudeToDecibel`.
@@ -234,6 +237,7 @@ def get_melspectrogram_layer(
         pad_end=pad_end,
         input_data_format=input_data_format,
         output_data_format=output_data_format,
+        use_parallel_stft=use_parallel_stft,
     )
 
     stft_to_stftm = Magnitude()
@@ -281,6 +285,7 @@ def get_log_frequency_spectrogram_layer(
     input_data_format='default',
     output_data_format='default',
     name='log_frequency_spectrogram',
+    use_parallel_stft=False,
 ):
     """A function that returns a log-frequency STFT layer, which is a `keras.Sequential` model consists of
     `STFT`, `Magnitude`, `ApplyFilterbank(_log_filterbank)`, and optionally `MagnitudeToDecibel`.
@@ -349,6 +354,7 @@ def get_log_frequency_spectrogram_layer(
         pad_end=pad_end,
         input_data_format=input_data_format,
         output_data_format=output_data_format,
+        use_parallel_stft=use_parallel_stft,
     )
 
     stft_to_stftm = Magnitude()
@@ -396,6 +402,7 @@ def get_perfectly_reconstructing_stft_istft(
     stft_data_format='default',
     stft_name='stft',
     istft_name='istft',
+    use_parallel_stft=False
 ):
     """A function that returns two layers, stft and inverse stft, which would be perfectly reconstructing pair.
 
@@ -483,6 +490,7 @@ def get_perfectly_reconstructing_stft_istft(
         input_data_format=waveform_data_format,
         output_data_format=stft_data_format,
         name=stft_name,
+        use_parallel_stft=use_parallel_stft,
     )
 
     stft_to_waveform = InverseSTFT(
@@ -514,6 +522,7 @@ def get_stft_mag_phase(
     input_data_format='default',
     output_data_format='default',
     name='stft_mag_phase',
+    use_parallel_stft=False
 ):
     """A function that returns magnitude and phase of input audio.
 
@@ -566,6 +575,7 @@ def get_stft_mag_phase(
         pad_end=pad_end,
         input_data_format=input_data_format,
         output_data_format=output_data_format,
+        use_parallel_stft=use_parallel_stft,
     )
 
     stft_to_stftm = Magnitude()

--- a/kapre/composed.py
+++ b/kapre/composed.py
@@ -73,6 +73,10 @@ def get_stft_magnitude_layer(
             `'channels_first'` if you want `(batch, channels, time, frequency)`
             Defaults to the setting of your Keras configuration. (tf.keras.backend.image_data_format())
         name (str): name of the returned layer
+        use_parallel_stft (bool): Whether to parallelize stft when running on CPU. If `True`, it uses
+            `kapre.backend.parallel_stft()` which uses multi-processing. If `False`, it uses Tensorflow
+            `tf.signal.stft`, which is significant slower than other STFT implementations such as librosa
+            or scipy on CPU. It does not affect the behavior when running on GPUs
 
     Note:
         STFT magnitude represents a linear-frequency spectrum of audio signal and probably the most popular choice
@@ -158,7 +162,7 @@ def get_melspectrogram_layer(
     input_data_format='default',
     output_data_format='default',
     name='melspectrogram',
-    use_parallel_stft=False
+    use_parallel_stft=False,
 ):
     """A function that returns a melspectrogram layer, which is a `keras.Sequential` model consists of
     `STFT`, `Magnitude`, `ApplyFilterbank(_mel_filterbank)`, and optionally `MagnitudeToDecibel`.
@@ -193,6 +197,10 @@ def get_melspectrogram_layer(
             `'channels_first'` if you want `(batch, channels, time, frequency)`
             Defaults to the setting of your Keras configuration. (tf.keras.backend.image_data_format())
         name (str): name of the returned layer
+        use_parallel_stft (bool): Whether to parallelize stft when running on CPU. If `True`, it uses
+            `kapre.backend.parallel_stft()` which uses multi-processing. If `False`, it uses Tensorflow
+            `tf.signal.stft`, which is significant slower than other STFT implementations such as librosa
+            or scipy on CPU. It does not affect the behavior when running on GPUs
 
     Note:
         Melspectrogram is originally developed for speech applications and has been *very* widely used for audio signal
@@ -319,6 +327,10 @@ def get_log_frequency_spectrogram_layer(
             `'channels_first'` if you want `(batch, channels, time, frequency)`
             Defaults to the setting of your Keras configuration. (tf.keras.backend.image_data_format())
         name (str): name of the returned layer
+        use_parallel_stft (bool): Whether to parallelize stft when running on CPU. If `True`, it uses
+            `kapre.backend.parallel_stft()` which uses multi-processing. If `False`, it uses Tensorflow
+            `tf.signal.stft`, which is significant slower than other STFT implementations such as librosa
+            or scipy on CPU. It does not affect the behavior when running on GPUs
 
     Note:
         Log-frequency spectrogram is similar to melspectrogram but its frequency axis is perfectly linear to octave scale.
@@ -402,7 +414,7 @@ def get_perfectly_reconstructing_stft_istft(
     stft_data_format='default',
     stft_name='stft',
     istft_name='istft',
-    use_parallel_stft=False
+    use_parallel_stft=False,
 ):
     """A function that returns two layers, stft and inverse stft, which would be perfectly reconstructing pair.
 
@@ -427,6 +439,10 @@ def get_perfectly_reconstructing_stft_istft(
             Defaults to the setting of your Keras configuration. (tf.keras.backend.image_data_format())
         stft_name (str): name of the returned STFT layer
         istft_name (str): name of the returned ISTFT layer
+        use_parallel_stft (bool): Whether to parallelize stft when running on CPU. If `True`, it uses
+            `kapre.backend.parallel_stft()` which uses multi-processing. If `False`, it uses Tensorflow
+            `tf.signal.stft`, which is significant slower than other STFT implementations such as librosa
+            or scipy on CPU. It does not affect the behavior when running on GPUs
 
 
     Note:
@@ -522,7 +538,7 @@ def get_stft_mag_phase(
     input_data_format='default',
     output_data_format='default',
     name='stft_mag_phase',
-    use_parallel_stft=False
+    use_parallel_stft=False,
 ):
     """A function that returns magnitude and phase of input audio.
 
@@ -551,6 +567,10 @@ def get_stft_mag_phase(
             `'channels_first'` if you want `(batch, channels, time, frequency)`
             Defaults to the setting of your Keras configuration. (tf.keras.backend.image_data_format())
         name (str): name of the returned layer
+        use_parallel_stft (bool): Whether to parallelize stft when running on CPU. If `True`, it uses
+            `kapre.backend.parallel_stft()` which uses multi-processing. If `False`, it uses Tensorflow
+            `tf.signal.stft`, which is significant slower than other STFT implementations such as librosa
+            or scipy on CPU. It does not affect the behavior when running on GPUs
 
     Example:
         ::

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -131,7 +131,7 @@ def test_validate_fail():
 @pytest.mark.parametrize('frame_length', [1024, 2048])
 @pytest.mark.parametrize('frame_step', [256, 512])
 @pytest.mark.parametrize('image_size', [256, 512, 1024])
-def test_parallel_stft_should_be_equal_to_tf_stft_on_cpu(frame_length, frame_step, image_size):
+def test_parallel_stft_correctness(frame_length, frame_step, image_size):
     prev_physical_devices_list = tf.config.get_visible_devices('GPU')
     tf.config.set_visible_devices([], 'GPU')
     test_array = tf.cast(tf.random.normal([image_size, image_size]), dtype=tf.float32)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -4,7 +4,7 @@ import librosa
 import tensorflow as tf
 from tensorflow.keras import backend as K
 from kapre import backend as KPB
-from kapre.backend import magnitude_to_decibel, validate_data_format_str
+from kapre.backend import magnitude_to_decibel, validate_data_format_str, parallel_stft
 
 from utils import SRC
 
@@ -126,6 +126,22 @@ def test_unsupported_window():
 @pytest.mark.xfail()
 def test_validate_fail():
     _ = validate_data_format_str('weird_string')
+
+
+@pytest.mark.parametrize('frame_length', [1024, 2048])
+@pytest.mark.parametrize('frame_step', [256, 512])
+@pytest.mark.parametrize('image_size', [256, 512, 1024])
+def test_parallel_stft_should_be_equal_to_tf_stft_on_cpu(frame_length, frame_step, image_size):
+    prev_physical_devices_list = tf.config.get_visible_devices('GPU')
+    tf.config.set_visible_devices([], 'GPU')
+    test_array = tf.cast(tf.random.normal([image_size, image_size]), dtype=tf.float32)
+    tf.test.TestCase().assertAllClose(
+        tf.signal.stft(test_array, frame_length, frame_step),
+        parallel_stft(test_array, frame_length, frame_step),
+        rtol=1e-4,
+        atol=1e-3,
+    )
+    tf.config.set_visible_devices(prev_physical_devices_list, 'GPU')
 
 
 if __name__ == '__main__':

--- a/tests/test_time_frequency.py
+++ b/tests/test_time_frequency.py
@@ -57,7 +57,8 @@ def allclose_complex_numbers(a, b, atol=1e-3):
 @pytest.mark.parametrize('hop_length', [None, 256])
 @pytest.mark.parametrize('n_ch', [1, 2, 6])
 @pytest.mark.parametrize('data_format', ['default', 'channels_first', 'channels_last'])
-def test_spectrogram_correctness(n_fft, hop_length, n_ch, data_format):
+@pytest.mark.parametrize('use_parallel_stft', [True, False])
+def test_spectrogram_correctness(n_fft, hop_length, n_ch, data_format, use_parallel_stft):
     def _get_stft_model(following_layer=None):
         # compute with kapre
         stft_model = tensorflow.keras.models.Sequential()
@@ -72,6 +73,7 @@ def test_spectrogram_correctness(n_fft, hop_length, n_ch, data_format):
                 output_data_format=data_format,
                 input_shape=input_shape,
                 name='stft',
+                use_parallel_stft=use_parallel_stft
             )
         )
         if following_layer is not None:
@@ -108,7 +110,8 @@ def test_spectrogram_correctness(n_fft, hop_length, n_ch, data_format):
 
 @pytest.mark.parametrize('data_format', ['channels_first', 'channels_last'])
 @pytest.mark.parametrize('window_name', [None, 'hann_window', 'hamming_window'])
-def test_spectrogram_correctness_more(data_format, window_name):
+@pytest.mark.parametrize('use_parallel_stft', [True, False])
+def test_spectrogram_correctness_more(data_format, window_name, use_parallel_stft):
     def _get_stft_model(following_layer=None):
         # compute with kapre
         stft_model = tensorflow.keras.models.Sequential()
@@ -123,6 +126,7 @@ def test_spectrogram_correctness_more(data_format, window_name):
                 output_data_format=data_format,
                 input_shape=input_shape,
                 name='stft',
+                use_parallel_stft=use_parallel_stft
             )
         )
         if following_layer is not None:
@@ -176,8 +180,9 @@ def test_spectrogram_correctness_more(data_format, window_name):
 @pytest.mark.parametrize('n_mels', [40])
 @pytest.mark.parametrize('mel_f_min', [0.0])
 @pytest.mark.parametrize('mel_f_max', [8000])
+@pytest.mark.parametrize('use_parallel_stft', [True, False])
 def test_melspectrogram_correctness(
-    n_fft, sr, hop_length, n_ch, data_format, amin, dynamic_range, n_mels, mel_f_min, mel_f_max
+    n_fft, sr, hop_length, n_ch, data_format, amin, dynamic_range, n_mels, mel_f_min, mel_f_max, use_parallel_stft
 ):
     """Test the correctness of melspectrogram.
 
@@ -201,6 +206,7 @@ def test_melspectrogram_correctness(
             input_shape=input_shape,
             db_amin=amin,
             db_dynamic_range=dynamic_range,
+            use_parallel_stft=use_parallel_stft,
         )
         return melgram_model
 
@@ -276,7 +282,8 @@ def test_delta():
 
 
 @pytest.mark.parametrize('data_format', ['default', 'channels_first', 'channels_last'])
-def test_mag_phase(data_format):
+@pytest.mark.parametrize('use_parallel_stft', [True, False])
+def test_mag_phase(data_format, use_parallel_stft):
     n_ch = 1
     n_fft, hop_length, win_length = 512, 256, 512
 
@@ -289,6 +296,7 @@ def test_mag_phase(data_format):
         hop_length=hop_length,
         input_data_format=data_format,
         output_data_format=data_format,
+        use_parallel_stft=use_parallel_stft
     )
     model = tensorflow.keras.models.Sequential()
     model.add(mag_phase_layer)
@@ -316,7 +324,8 @@ def test_mag_phase(data_format):
 @pytest.mark.parametrize('waveform_data_format', ['default', 'channels_first', 'channels_last'])
 @pytest.mark.parametrize('stft_data_format', ['default', 'channels_first', 'channels_last'])
 @pytest.mark.parametrize('hop_ratio', [0.5, 0.25, 0.125])
-def test_perfectly_reconstructing_stft_istft(waveform_data_format, stft_data_format, hop_ratio):
+@pytest.mark.parametrize('use_parallel_stft', [True, False])
+def test_perfectly_reconstructing_stft_istft(waveform_data_format, stft_data_format, hop_ratio, use_parallel_stft):
     n_ch = 1
     src_mono, batch_src, input_shape = get_audio(data_format=waveform_data_format, n_ch=n_ch)
     time_axis = 1 if waveform_data_format == 'channels_first' else 0  # non-batch!
@@ -332,6 +341,7 @@ def test_perfectly_reconstructing_stft_istft(waveform_data_format, stft_data_for
         hop_length=hop_length,
         waveform_data_format=waveform_data_format,
         stft_data_format=stft_data_format,
+        use_parallel_stft=use_parallel_stft
     )
     # Test - [STFT -> ISTFT]
     model = tf.keras.models.Sequential([stft, istft])

--- a/tests/test_time_frequency.py
+++ b/tests/test_time_frequency.py
@@ -73,7 +73,7 @@ def test_spectrogram_correctness(n_fft, hop_length, n_ch, data_format, use_paral
                 output_data_format=data_format,
                 input_shape=input_shape,
                 name='stft',
-                use_parallel_stft=use_parallel_stft
+                use_parallel_stft=use_parallel_stft,
             )
         )
         if following_layer is not None:
@@ -126,7 +126,7 @@ def test_spectrogram_correctness_more(data_format, window_name, use_parallel_stf
                 output_data_format=data_format,
                 input_shape=input_shape,
                 name='stft',
-                use_parallel_stft=use_parallel_stft
+                use_parallel_stft=use_parallel_stft,
             )
         )
         if following_layer is not None:
@@ -182,7 +182,17 @@ def test_spectrogram_correctness_more(data_format, window_name, use_parallel_stf
 @pytest.mark.parametrize('mel_f_max', [8000])
 @pytest.mark.parametrize('use_parallel_stft', [True, False])
 def test_melspectrogram_correctness(
-    n_fft, sr, hop_length, n_ch, data_format, amin, dynamic_range, n_mels, mel_f_min, mel_f_max, use_parallel_stft
+    n_fft,
+    sr,
+    hop_length,
+    n_ch,
+    data_format,
+    amin,
+    dynamic_range,
+    n_mels,
+    mel_f_min,
+    mel_f_max,
+    use_parallel_stft,
 ):
     """Test the correctness of melspectrogram.
 
@@ -296,7 +306,7 @@ def test_mag_phase(data_format, use_parallel_stft):
         hop_length=hop_length,
         input_data_format=data_format,
         output_data_format=data_format,
-        use_parallel_stft=use_parallel_stft
+        use_parallel_stft=use_parallel_stft,
     )
     model = tensorflow.keras.models.Sequential()
     model.add(mag_phase_layer)
@@ -325,7 +335,9 @@ def test_mag_phase(data_format, use_parallel_stft):
 @pytest.mark.parametrize('stft_data_format', ['default', 'channels_first', 'channels_last'])
 @pytest.mark.parametrize('hop_ratio', [0.5, 0.25, 0.125])
 @pytest.mark.parametrize('use_parallel_stft', [True, False])
-def test_perfectly_reconstructing_stft_istft(waveform_data_format, stft_data_format, hop_ratio, use_parallel_stft):
+def test_perfectly_reconstructing_stft_istft(
+    waveform_data_format, stft_data_format, hop_ratio, use_parallel_stft
+):
     n_ch = 1
     src_mono, batch_src, input_shape = get_audio(data_format=waveform_data_format, n_ch=n_ch)
     time_axis = 1 if waveform_data_format == 'channels_first' else 0  # non-batch!
@@ -341,7 +353,7 @@ def test_perfectly_reconstructing_stft_istft(waveform_data_format, stft_data_for
         hop_length=hop_length,
         waveform_data_format=waveform_data_format,
         stft_data_format=stft_data_format,
-        use_parallel_stft=use_parallel_stft
+        use_parallel_stft=use_parallel_stft,
     )
     # Test - [STFT -> ISTFT]
     model = tf.keras.models.Sequential([stft, istft])


### PR DESCRIPTION
Hi!

As I comented in #98, I added a parallel STFT implementation based on the map_fn function following the indications of @zaccharieramzi [here](https://github.com/tensorflow/tensorflow/issues/6541#issuecomment-728947886).

I've added a `use_parallel_stft` param (disabled by default) that allows to use this function. I've put this param in as many functions as I can. I also added test cases for every function I can, including an specific test that checks that the result of the `tf.signal.stft` is equals to the result of the `parallel_stft` function.

Hope this could serve us well meanwhile tensorflow resolves its issues with the fft implementation.