### PR TITLE
Tensorflow as an extra requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 install:
     - python -m pip install --upgrade pip
-    - pip install --pre -e .
+    - pip install --pre -e .'[tf]'
 #    - pip install black
 
 script:

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Tested on Python 3.6 and 3.7
 5. When deploying the final model, all you need to remember is the sampling rate of the signal. No dependency or preprocessing!
 
 ## Installation
- 
+To install with cpu only tensorflow:
 ```sh
 pip install kapre[tf]
 ```
-or for a gpu enabled version of tensorflow
+for tensorflow-gpu:
 ```sh
 pip install kapre[tf_gpu]
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ Tested on Python 3.6 and 3.7
 ## Installation
  
 ```sh
-pip install kapre
+pip install kapre[tf]
+```
+or for a gpu enabled version of tensorflow
+```sh
+pip install kapre[tf_gpu]
 ```
 
 ## API Documentation

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,11 @@ setup(
     install_requires=[
         'numpy >= 1.18.5',
         'librosa >= 0.7.2',
-        'tensorflow >= 2.0',
     ],
+    extras_require={
+        'tf': ['tensorflow>=2.0.0'],
+        'tf_gpu': ['tensorflow-gpu>=2.0.0'],
+    },
     keywords='audio music speech sound deep learning keras tensorflow',
     zip_safe=False,
 )


### PR DESCRIPTION
Hi, I was having trouble using kapre in a tensorflow docker container with a gpu as it is not aware of the presence of a GPU version of tensor flow, so I created a fork to address this issue.

With tensorflow listed under `install_requires` as `tensorflow >= 2.0` if you have the gpu version of tensorflow (e.g. in a gpu enable docker container `docker run -it --rm --runtime=nvidia tensorflow/tensorflow:latest-gpu python` this will download and install the cpu version of tensorflow.

To get around this I have moved the tf dependancy to an `extras_require`. This changes the behaviour so that `pip install kapre[tf]` installs the cpu version and `pip install kapre[tf_gpu]` brings the gpu tf version. This is similar to:

https://github.com/tensorflow/tensorflow/issues/7166#issuecomment-280881808

`pip install kapre` still works but won't bring tensorflow, this seems to be the best way to deal with this problem as far as I can see. I modified the readme also.