### PR TITLE
magnitude_to_decibel support for float16+float64

### DIFF
--- a/kapre/backend.py
+++ b/kapre/backend.py
@@ -110,6 +110,7 @@ def magnitude_to_decibel(x, ref_value=1.0, amin=1e-5, dynamic_range=80.0):
     if amin is None:
         amin = 1e-5
 
+    amin = tf.cast(amin, dtype=x.dtype)
     log_spec = 10.0 * _log10(tf.math.maximum(x, amin))
     log_spec = log_spec - 10.0 * _log10(tf.math.maximum(amin, ref_value))
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -12,10 +12,11 @@ TOL = 1e-5
 
 
 @pytest.mark.parametrize('dynamic_range', [80.0, 120.0])
-def test_magnitude_to_decibel(dynamic_range):
+@pytest.mark.parametrize('dtype', ['float16', 'float32', 'float64'])
+def test_magnitude_to_decibel(dynamic_range, dtype: str):
     """test for backend_keras.magnitude_to_decibel"""
 
-    x = np.array([[1e-20, 1e-5, 1e-3, 5e-2], [0.3, 1.0, 20.5, 9999]])  # random positive numbers
+    x = np.array([[1e-20, 1e-5, 1e-3, 5e-2], [0.3, 1.0, 20.5, 9999]], dtype=dtype)  # random positive numbers
 
     amin = 1e-5
     x_decibel_ref = np.stack(
@@ -30,8 +31,10 @@ def test_magnitude_to_decibel(dynamic_range):
     x_decibel_kapre = magnitude_to_decibel(
         x_var, ref_value=1.0, amin=amin, dynamic_range=dynamic_range
     )
-
-    np.testing.assert_allclose(K.eval(x_decibel_kapre), x_decibel_ref, atol=TOL)
+    if dtype == 'float16':
+        np.testing.assert_allclose(K.eval(x_decibel_kapre), x_decibel_ref, rtol=1e-3, atol=TOL)
+    else:
+        np.testing.assert_allclose(K.eval(x_decibel_kapre), x_decibel_ref, atol=TOL)
 
 
 @pytest.mark.parametrize('sample_rate', [44100, 22050])


### PR DESCRIPTION
The function kapre.backend.magnitude_to_decibel with the default
arguments throws a TensorFlow type error if `x` is not `float32`.

We can fix this by casting `amin` to `x`'s dtype.

Previously, the Keras layer `kapre.time_frequency.MagnitudeToDecibel`
avoided these errors by casting arguments to `float32`, but this
change also fixes the layer if initialized as
`MagnitudeToDecibel(dtype=tf.float64)` or
`MagnitudeToDecibel(dtype=tf.float16)`