### PR TITLE
Fix magnitude_to_decibel docs to reference librosa

### DIFF
--- a/kapre/backend.py
+++ b/kapre/backend.py
@@ -71,7 +71,7 @@ def magnitude_to_decibel(x, ref_value=1.0, amin=1e-5, dynamic_range=80.0):
     """A function that converts magnitude to decibel scaling.
     In essence, it runs `10 * log10(x)`, but with some other utility operations.
 
-    Similar to `librosa.amplitude_to_db` with `ref=1.0` and `top_db=dynamic_range`
+    Similar to `librosa.power_to_db` with `ref=1.0` and `top_db=dynamic_range`
 
     Args:
         x (`Tensor`): float tensor. Can be batch or not. Something like magnitude of STFT.


### PR DESCRIPTION
The function [`kapre.backend.magnitude_to_decibel`][1] is actually an equivalent to [`librosa.power_to_db`][2] instead of [`librosa.amplitude_to_db`][3].

You can see this in [Kapre's unit tests][4] where `magnitude_to_decibel` is compared against `power_to_db`.

You can also verify the current working behavior with this example:
```python
import numpy as np
import tensorflow as tf

import kapre
import librosa


ref = 1.0
amin = 1e-05
top_db = 80.0
a = np.array([0.0, amin, 1.0, 10.0, 100.0])

print(
    "librosa.amplitude_to_db",
    librosa.amplitude_to_db(
        a,ref=ref,
        amin=amin,
        top_db=top_db,
    ),
    "",
    sep="\n",
)

print(
    "librosa.power_to_db",
    librosa.power_to_db(
        a,
        ref=ref,
        amin=amin,
        top_db=top_db,
    ),
    "",
    sep="\n",
)

print(
    "kapre.backend.magnitude_to_decibel",
    kapre.backend.magnitude_to_decibel(
        tf.convert_to_tensor(a),
        ref_value=ref,
        amin=amin,
        dynamic_range=top_db,
    ).numpy(),
    "",
    sep="\n",
)
```
[1]: https://kapre.readthedocs.io/en/latest/backend.html#kapre.backend.magnitude_to_decibel
[2]: https://librosa.org/doc/0.8.0/generated/librosa.power_to_db.html
[3]: https://librosa.org/doc/0.8.0/generated/librosa.amplitude_to_db.html
[4]: https://github.com/keunwoochoi/kapre/blob/ff6fe77cda572ee8eac4f35502925b62a84e491d/tests/test_backend.py#L16