### PR TITLE
Fix STFT docs about default value for hop_length

### DIFF
--- a/kapre/time_frequency.py
+++ b/kapre/time_frequency.py
@@ -68,7 +68,7 @@ class STFT(Layer):
     Args:
         n_fft (int): Number of FFTs. Defaults to `2048`
         win_length (int or None): Window length in sample. Defaults to `n_fft`.
-        hop_length (int or None): Hop length in sample between analysis windows. Defaults to `n_fft // 4` following Librosa.
+        hop_length (int or None): Hop length in sample between analysis windows. Defaults to `win_length // 4` following Librosa.
         window_name (str or None): *Name* of `tf.signal` function that returns a 1D tensor window that is used in analysis.
             Defaults to `hann_window` which uses `tf.signal.hann_window`.
             Window availability depends on Tensorflow version. More details are at `kapre.backend.get_window()`.


### PR DESCRIPTION
Both Librosa and Kapre set the default value for `hop_length` to `win_length // 4` as opposed to `n_fft // 4`. Most users won't notice the difference because, by default, `win_length = n_fft` in both Kapre and Librosa.

You can see how the defaults are set in the [Kapre source code][1] or the [Librosa documentation][2].

[1]: https://github.com/keunwoochoi/kapre/blob/76433544a6a01739dec33fbac43d4c81c520aae5/kapre/composed.py#L459
[2]: http://librosa.org/doc/main/generated/librosa.stft.html