### PR TITLE
Clean up packaging metadata

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include tests/speech_test_file.npz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
+[build-system]
+requires = ["setuptools >= 61", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 100
-target-version = ['py38']
+target-version = ['py39']
 skip-string-normalization = true
 include = '\.pyi?$'
 exclude = '''

--- a/scripts/apply-black.sh
+++ b/scripts/apply-black.sh
@@ -1,2 +1,4 @@
-black kapre
-black tests
+#!/bin/bash
+set -euo pipefail
+
+black kapre tests scripts

--- a/scripts/upload-to-pypi.sh
+++ b/scripts/upload-to-pypi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+set -euo pipefail
 
 rm -rf dist
-python setup.py sdist bdist_wheel
-python setup.py sdist
-pip install twine
-twine upload dist/*
+python -m pip install --upgrade --quiet build twine
+python -m build
+python -m twine upload dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[metadata]
-description-file = README.md
-

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,65 @@
-import re
 import os
+import re
 from setuptools import setup
 
+
 def get_version():
-    with open(os.path.join('kapre', '__init__.py'), 'r') as f:
-        return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", f.read()).group(1)
+    with open(os.path.join('kapre', '__init__.py'), 'r', encoding='utf-8') as f:
+        match = re.search(r"__version__\s*=\s*['\"]([^'\"]+)['\"]", f.read())
+        if match:
+            return match.group(1)
+        raise RuntimeError("Unable to find version string in kapre/__init__.py")
+
+
+def get_long_description():
+    with open('README.md', 'r', encoding='utf-8') as f:
+        return f.read()
+
 
 setup(
     name='kapre',
     version=get_version(),
     description='Kapre: Keras Audio Preprocessors. Tensorflow.Keras layers for audio pre-processing in deep learning',
+    long_description=get_long_description(),
+    long_description_content_type='text/markdown',
     author='Keunwoo Choi',
-    url='http://github.com/keunwoochoi/kapre/',
+    url='https://github.com/keunwoochoi/kapre/',
     author_email='gnuchoi@gmail.com',
     license='MIT',
     packages=['kapre'],
-    package_data={
-        'kapre': [
-            'tests/speech_test_file.npz',
-        ]
-    },
-    include_package_data=True,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=[
-        'numpy >= 2.0.0',
+        'numpy >= 1.26.0, < 3.0.0',
         'librosa >= 0.11.0, < 1.0.0',
+        # Keras 3.14.x currently breaks TensorFlow 2.20 TFLite conversion on Python 3.12+.
+        'keras >= 3.0.0, < 3.14.0',
         'tensorflow >= 2.16.0, < 2.21.0',
+    ],
+    extras_require={
+        'dev': [
+            'black >= 24.0',
+            'flake8 >= 7.0',
+            'mypy >= 1.8',
+            'pyright >= 1.1',
+            'pytest >= 8.0',
+        ],
+        'docs': [
+            'sphinx >= 7.0',
+            'sphinx-rtd-theme >= 2.0',
+        ],
+    },
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Topic :: Multimedia :: Sound/Audio :: Analysis',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
     ],
     keywords='audio music speech sound deep learning keras tensorflow',
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,45 +1,21 @@
 [tox]
-envlist = py38,py39,py310,py311,black
+envlist = py39,py310,py311,py312,py313,black
 skipsdist = False
 usedevelop = True
+skip_missing_interpreters = True
 
 [testenv]
-whitelist_externals = python
-
-[testenv:py38]
-basepython = python3.8
 deps =
     pytest
 commands =
-    py.test {posargs}
-
-[testenv:py39]
-basepython = python3.9
-deps =
-    pytest
-commands =
-    py.test {posargs}
-
-[testenv:py310]
-basepython = python3.10
-deps =
-    pytest
-commands =
-    py.test {posargs}
-
-[testenv:py311]
-basepython = python3.11
-deps =
-    pytest
-commands =
-    py.test {posargs}
+    pytest {posargs}
 
 [testenv:black]
 ; "black" is a code formatter, much like gofmt. It requires 3.6 or higher.
 ; Tingle has 3.6 available to it; but feel free to uncomment the line
 ; `ignore_outcome` if it fails. Docs: https://github.com/ambv/black
 ;ignore_outcome = true
-basepython = python3.8
+basepython = python3.9
 deps = black
 skip_install = true
 commands =


### PR DESCRIPTION
## Summary

Packaging/build metadata cleanup only.

- Add PEP 517/518 build metadata in `pyproject.toml`.
- Set `python_requires` to `>=3.9`, matching current TensorFlow support and the maintained test matrix.
- Loosen NumPy floor to `>=1.26,<3.0` so the package metadata is compatible with TensorFlow 2.16/2.17 while remaining capped before NumPy 3.
- Add `dev` and `docs` extras.
- Add PyPI long description metadata and standard classifiers.
- Replace the broken `package_data` entry for `tests/speech_test_file.npz` with `MANIFEST.in` so the test fixture is included in the sdist but not in the runtime wheel.
- Modernize release/format scripts around `python -m build` and `python -m twine`.

## Risk / behavior

No runtime source changes. This only changes packaging metadata, source distribution contents, and helper scripts.

## Tests / verification

- `python -m build` passed.
- `twine check dist/*` passed for wheel and sdist.
- Verified `tests/speech_test_file.npz` is present in the sdist.
- Verified the wheel does not include the test fixture, as intended.
- `pip install -e '.[dev]' --dry-run` passed.
- `pip install -e '.[docs]' --dry-run` passed.

## Follow-up / related

The NumPy 1.26 floor is validated end-to-end by the oldest-supported CI job added in the follow-up CI/docs PR. Best merged together with or before that PR.
