### PR TITLE
Refresh CI and documentation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,26 +16,63 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        include:
+          - python-version: "3.9"
+            tensorflow-package: ""
+          - python-version: "3.10"
+            tensorflow-package: ""
+          - python-version: "3.11"
+            tensorflow-package: ""
+          - python-version: "3.12"
+            tensorflow-package: ""
+          # TensorFlow 2.20 is currently the only <2.21 release with CPython 3.13 wheels.
+          - python-version: "3.13"
+            tensorflow-package: "tensorflow==2.20.*"
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: "pip"
     - name: Install dependencies
+      env:
+        TENSORFLOW_PACKAGE: ${{ matrix.tensorflow-package }}
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f setup.py ]; then pip install .; fi
+        # TensorFlow Lite conversion fails with Keras 3.14.x on Python >= 3.12.
+        python -m pip install pytest "keras<3.14"
+        if [ -n "$TENSORFLOW_PACKAGE" ]; then
+          python -m pip install "$TENSORFLOW_PACKAGE"
+        fi
+        python -m pip install .
     # - name: Lint with flake8
     #   run: |
     #     # stop the build if there are Python syntax errors or undefined names
     #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
     #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest
+
+  oldest-supported:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.9"
+        cache: "pip"
+    - name: Install oldest supported dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest numpy==1.26.4 librosa==0.11.0 "keras<3.14" tensorflow==2.16.2
+        python -m pip install --no-deps .
     - name: Test with pytest
       run: |
         pytest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kapre
 Keras Audio Preprocessors - compute STFT, ISTFT, Melspectrogram, and others on GPU real-time.
  
-Tested on Python 3.8+, with type hints for better development experience
+Tested on Python 3.9+ with TensorFlow 2.16-2.20, with type hints for better development experience
 
 ## Why Kapre?
 
@@ -87,7 +87,7 @@ Please refer to Kapre API Documentation at https://kapre.readthedocs.io
 
 ```python
 from tensorflow.keras.models import Sequential
-from tensorflow.keras.layers import Conv2D, BatchNormalization, ReLU, GlobalAveragePooling2D, Dense, Softmax
+from tensorflow.keras.layers import Input, Conv2D, BatchNormalization, ReLU, GlobalAveragePooling2D, Dense, Softmax
 from kapre import STFT, Magnitude, MagnitudeToDecibel
 from kapre.composed import get_melspectrogram_layer, get_log_frequency_spectrogram_layer
 
@@ -95,11 +95,11 @@ from kapre.composed import get_melspectrogram_layer, get_log_frequency_spectrogr
 input_shape = (44100, 6)
 sr = 44100
 model = Sequential()
+model.add(Input(shape=input_shape))
 # A STFT layer
-model.add(STFT(n_fft=2048, win_length=2018, hop_length=1024,
+model.add(STFT(n_fft=2048, win_length=2048, hop_length=1024,
                window_name=None, pad_end=False,
-               input_data_format='channels_last', output_data_format='channels_last',
-               input_shape=input_shape))
+               input_data_format='channels_last', output_data_format='channels_last'))
 model.add(Magnitude())
 model.add(MagnitudeToDecibel())  # these three layers can be replaced with get_stft_magnitude_layer()
 # Alternatively, you may want to use a melspectrogram layer
@@ -120,7 +120,7 @@ model.compile('adam', 'categorical_crossentropy') # if single-label classificati
 
 # train it with raw audio sample inputs
 # for example, you may have functions that load your data as below.
-x = load_x() # e.g., x.shape = (10000, 6, 44100)
+x = load_x() # e.g., x.shape = (10000, 44100, 6)
 y = load_y() # e.g., y.shape = (10000, 10) if it's 10-class classification
 # then..
 model.fit(x, y)
@@ -129,23 +129,23 @@ model.fit(x, y)
 
 * See the Jupyter notebook at the [example folder](https://github.com/keunwoochoi/kapre/tree/master/examples)
 
-## Tflite compatbility
+## TFLite compatibility
 
-The `STFT` layer is not tflite compatible (due to `tf.signal.stft`). To create a tflite
+The `STFT` layer is not TFLite compatible (due to `tf.signal.stft`). To create a TFLite
 compatible model, first train using the normal `kapre` layers then create a new
 model replacing `STFT` and `Magnitude` with `STFTTflite`, `MagnitudeTflite`.
-Tflite compatible layers are restricted to a batch size of 1 which prevents use
+TFLite compatible layers are restricted to a batch size of 1 which prevents use
 of them during training.
 
 ```python
 # assumes you have run the one-shot example above.
 from kapre import STFTTflite, MagnitudeTflite
 model_tflite = Sequential()
+model_tflite.add(Input(shape=input_shape))
 
-model_tflite.add(STFTTflite(n_fft=2048, win_length=2018, hop_length=1024,
+model_tflite.add(STFTTflite(n_fft=2048, win_length=2048, hop_length=1024,
                window_name=None, pad_end=False,
-               input_data_format='channels_last', output_data_format='channels_last',
-               input_shape=input_shape))
+               input_data_format='channels_last', output_data_format='channels_last'))
 model_tflite.add(MagnitudeTflite())
 model_tflite.add(MagnitudeToDecibel())  
 model_tflite.add(Conv2D(32, (3, 3), strides=(2, 2)))
@@ -172,4 +172,3 @@ Please cite this paper if you use Kapre for your work.
   organization={ICML}
 }
 ```
-

--- a/docs/.readthedocs.yml
+++ b/docs/.readthedocs.yml
@@ -1,7 +1,13 @@
 version: 2
 
+build:
+   os: ubuntu-24.04
+   tools:
+      python: "3.12"
+
+sphinx:
+   configuration: docs/conf.py
+
 python:
-   version: 3.7
    install:
       - requirements: docs/requirements.txt
-   system_packages: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,11 +13,23 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../'))
+import re
+from importlib.util import find_spec
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
+sys.path.insert(0, ROOT_DIR)
 import sphinx_rtd_theme
 
-autodoc_mock_imports = ['tensorflow', 'librosa', 'numpy']
+autodoc_mock_imports = [
+    dependency
+    for dependency in ('tensorflow', 'librosa', 'numpy')
+    if find_spec(dependency) is None
+]
 autodoc_member_order = 'bysource'
+if autodoc_mock_imports:
+    # When TensorFlow is mocked on Read the Docs, Sphinx reports mocked decorator signature warnings under the generic "autodoc" warning type; keeping this conditional preserves -W for references, rST, toctrees, and other documentation issues when the real dependencies are installed.
+    suppress_warnings = ['autodoc']
 
 
 # -- Project information -----------------------------------------------------
@@ -27,7 +39,11 @@ copyright = '2020, Keunwoo Choi, Deokjin Joo and Juho Kim'
 author = 'Keunwoo Choi, Deokjin Joo and Juho Kim'
 
 # The full version, including alpha/beta/rc tags
-release = '2017'
+with open(os.path.join(ROOT_DIR, 'kapre', '__init__.py'), 'r', encoding='utf-8') as f:
+    match = re.search(r"__version__\s*=\s*['\"]([^'\"]+)['\"]", f.read())
+    if not match:
+        raise RuntimeError("Unable to find version string in kapre/__init__.py")
+    release = match.group(1)
 
 # -- General configuration ---------------------------------------------------
 
@@ -40,15 +56,7 @@ extensions = [
     "sphinx.ext.viewcode",  # source linkage
     "sphinx.ext.napoleon",
     # "sphinx.ext.autosummary",
-    "sphinx.ext.viewcode",  # source linkage
-    "sphinxcontrib.inlinesyntaxhighlight"  # inline code highlight
 ]
-
-# https://stackoverflow.com/questions/21591107/sphinx-inline-code-highlight
-# use language set by highlight directive if no language is set by role
-inline_highlight_respect_highlight = True
-# use language set by highlight directive if no role is set
-inline_highlight_literals = True
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
@@ -84,9 +92,4 @@ html_css_files = [
 ]
 
 
-def setup(app):
-    app.add_stylesheet("css/custom.css")
-
-
 master_doc = 'index'
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Kapre
 
 Keras Audio Preprocessors - compute STFT, InverseSTFT, Melspectrogram, and others on GPU real-time.
   
-Tested on Python 3.6, and 3.7.
+Tested on Python 3.9+ with TensorFlow 2.16-2.20.
 
 Why Kapre?
 ----------
@@ -99,4 +99,3 @@ Visit `github.com/keunwoochoi/kapre <https://github.com/keunwoochoi/kapre>`_ and
    :caption: Info
 
    release_note
-

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -55,7 +55,7 @@ Use STFT Magnitude
     input_shape = (int(sampling_rate * duration), num_channel)  # let's follow `channels_last` convention
 
     model = Sequential()
-    model.add(STFT(n_fft=2048, win_length=2018, hop_length=1024,
+    model.add(STFT(n_fft=2048, win_length=2048, hop_length=1024,
                    window_name='hann_window', pad_end=False,
                    input_data_format='channels_last', output_data_format='channels_last',
                    input_shape=input_shape))  # complex64
@@ -162,6 +162,5 @@ Use STFT Magnitude -- a lazy version
     Non-trainable params: 0
     _________________________________________________________________
     """
-
 
 

--- a/docs/release_note.rst
+++ b/docs/release_note.rst
@@ -1,75 +1,95 @@
 Release Note
 ^^^^^^^^^^^^
 
-* 21 Jan 2022
-  - 0.3.7
-    - Add [SpecAugment](https://github.com/keunwoochoi/kapre/pull/135) layer
+0.4.0 - 13 Oct 2025
+-------------------
 
-* 13 Nov 2021
-  - 0.3.6
-    - bugfix/pad end tflite #131
+* Add Keras 3 / TensorFlow 2.16-2.20 compatibility fixes.
+* Update the tested dependency floor to Python 3.9, NumPy 1.26+, and librosa 0.11+.
+* Add type-checking configuration and refresh serialization tests.
 
-* 18 March 2021
-  - 0.3.5
-    - Add `kapre.time_frequency_tflite` which uses tflite for a faster CPU inference.
+0.3.7 - 21 Jan 2022
+-------------------
 
-* 29 Sep 2020
-  - 0.3.4
-    - Fix a bug in `kapre.backend.get_window_fn()`. Previously, it only correctly worked with `None` input and an error was raised when non-default value was set for `window_name` in any layer.
+* Add `SpecAugment <https://github.com/keunwoochoi/kapre/pull/135>`_ layer.
 
-* 15 Sep 2020
-  - 0.3.3
-    - `kapre.augmentation` is added
-    - `kapre.time_frequency.ConcatenateFrequencyMap` is added
-    - `kapre.composed.get_frequency_aware_conv2d` is added
-    - In `STFT` and `InverseSTFT`, keyword arg `window_fn` is renamed to `window_name` and it expects string value, not function.
-      - With this update, models with Kapre layers can be loaded with `h5` file format.
-    - `kapre.backend.get_window_fn` is added
+0.3.6 - 13 Nov 2021
+-------------------
 
-* 28 Aug 2020
-  - 0.3.2
-    - `kapre.signal.Frame` and `kapre.signal.Energy` are added
-    - `kapre.signal.LogmelToMFCC` is added
-    - `kapre.signal.MuLawEncoder` and `kapre.signal.MuLawDecoder` are added
-    - `kapre.composed.get_stft_magnitude_layer()` is added
-* 21 Aug 2020
-  - 0.3.1
-    - `Inverse STFT` is added
+* Fix ``pad_end`` in the TFLite-compatible layers, via #131.
 
-* 15 Aug 2020
-  - 0.3.0
-    - Breaking and simplifying changes with Tensorflow 2.0 and more tests. Some features are removed.
+0.3.5 - 18 March 2021
+---------------------
 
-* 29 Jul 2020
-  - 0.2.0
-    - Change melspectrogram filterbank from `norm=1` to `norm='slaney'` (w.r.t. Librosa) due to the update from Librosa (https://github.com/keunwoochoi/kapre/issues/77)
-    This would change the behavior of melspectrogram slightly.
-    - Bump librosa version to 0.7.2 or higher.
+* Add ``kapre.time_frequency_tflite`` which uses TFLite for faster CPU inference.
 
-* 17 Mar 2020
-  - 0.1.8
-    - added `utils.Delta` layer
+0.3.4 - 29 Sep 2020
+-------------------
 
-* 20 Feb 2020
-  - Kapre ver 0.1.7
-    - No vanilla Keras dependency
-    - Tensorflow >= 1.15 only
-    - Not tested on Python 2.7 anymore; only on Python 3.6 and 3.7 locally (by `tox`) and 3.6 on Travis
+* Fix a bug in ``kapre.backend.get_window_fn()``. Previously, it only correctly worked with ``None`` input and an error was raised when non-default value was set for ``window_name`` in any layer.
 
-* 20 Feb 2019
-  - Kapre ver 0.1.4
-    - Fixed amplitude-to-decibel error as raised in https://github.com/keunwoochoi/kapre/issues/46
+0.3.3 - 15 Sep 2020
+-------------------
 
-* March 2018
-  - Kapre ver 0.1.3
-    - Kapre is on Pip again
-    - Add unit tests
-    - Remove `Datasets`
-    - Remove some codes while adding more dependency on Librosa to make it cleaner and more stable
-      - and therefore `htk` option enabled in `Melspectrogram`
+* Add ``kapre.augmentation``.
+* Add ``kapre.time_frequency.ConcatenateFrequencyMap``.
+* Add ``kapre.composed.get_frequency_aware_conv2d``.
+* In ``STFT`` and ``InverseSTFT``, rename keyword argument ``window_fn`` to ``window_name`` and expect a string value, not a function. With this update, models with Kapre layers can be loaded with ``h5`` file format.
+* Add ``kapre.backend.get_window_fn``.
 
-* 9 July 2017
-  - Kapre ver 0.1.1, aka 'pretty stable' with a benchmark paper, https://arxiv.org/abs/1706.05781
-    - Remove STFT, python3 compatible
-    - A full documentation in this readme.md
-    - pip version is updated
+0.3.2 - 28 Aug 2020
+-------------------
+
+* Add ``kapre.signal.Frame`` and ``kapre.signal.Energy``.
+* Add ``kapre.signal.LogmelToMFCC``.
+* Add ``kapre.signal.MuLawEncoder`` and ``kapre.signal.MuLawDecoder``.
+* Add ``kapre.composed.get_stft_magnitude_layer()``.
+
+0.3.1 - 21 Aug 2020
+-------------------
+
+* Add ``Inverse STFT``.
+
+0.3.0 - 15 Aug 2020
+-------------------
+
+* Make breaking and simplifying changes with TensorFlow 2.0 and more tests. Some features are removed.
+
+0.2.0 - 29 Jul 2020
+-------------------
+
+* Change melspectrogram filterbank from ``norm=1`` to ``norm='slaney'`` (w.r.t. Librosa) due to the update from Librosa: https://github.com/keunwoochoi/kapre/issues/77. This changes the behavior of melspectrogram slightly.
+* Bump librosa version to 0.7.2 or higher.
+
+0.1.8 - 17 Mar 2020
+-------------------
+
+* Add ``utils.Delta`` layer.
+
+0.1.7 - 20 Feb 2020
+-------------------
+
+* Remove vanilla Keras dependency.
+* Require TensorFlow >= 1.15 only.
+* Stop testing on Python 2.7; test only on Python 3.6 and 3.7 locally (by ``tox``) and 3.6 on Travis.
+
+0.1.4 - 20 Feb 2019
+-------------------
+
+* Fix amplitude-to-decibel error as raised in https://github.com/keunwoochoi/kapre/issues/46.
+
+0.1.3 - March 2018
+------------------
+
+* Put Kapre on PyPI again.
+* Add unit tests.
+* Remove ``Datasets``.
+* Remove some code while adding more dependency on Librosa to make it cleaner and more stable, enabling the ``htk`` option in ``Melspectrogram``.
+
+0.1.1 - 9 July 2017
+-------------------
+
+* Release the “pretty stable” version with a benchmark paper: https://arxiv.org/abs/1706.05781.
+* Remove STFT, make Python 3 compatible.
+* Add full documentation in ``README.md``.
+* Update the PyPI version.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,2 @@
-sphinx!=1.3.1
-sphinx_rtd_theme
-sphinxcontrib-napoleon
-sphinxcontrib-inlinesyntaxhighlight
+sphinx >= 7.0
+sphinx-rtd-theme >= 2.0

--- a/kapre/time_frequency.py
+++ b/kapre/time_frequency.py
@@ -419,7 +419,7 @@ class MagnitudeToDecibel(Layer):
         ref_value (`float`): an input value that would become 0 dB in the result.
             For spectrogram magnitudes, ref_value=1.0 usually make the decibel-scaled output to be around zero
             if the input audio was in [-1, 1].
-        amin (`float`): the noise floor of the input. An input that is smaller than `amin`, it's converted to `amin.
+        amin (`float`): the noise floor of the input. An input that is smaller than `amin`, it's converted to `amin`.
         dynamic_range (`float`): range of the resulting value. E.g., if the maximum magnitude is 30 dB,
             the noise floor of the output would become (30 - dynamic_range) dB
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -11,7 +11,7 @@
   ],
   "reportMissingImports": true,
   "reportMissingTypeStubs": false,
-  "pythonVersion": "3.8",
+  "pythonVersion": "3.9",
   "typeCheckingMode": "basic",
   "reportUnknownMemberType": false,
   "reportUnknownVariableType": false,

--- a/tox.ini
+++ b/tox.ini
@@ -1,45 +1,21 @@
 [tox]
-envlist = py38,py39,py310,py311,black
+envlist = py39,py310,py311,py312,py313,black
 skipsdist = False
 usedevelop = True
+skip_missing_interpreters = True
 
 [testenv]
-whitelist_externals = python
-
-[testenv:py38]
-basepython = python3.8
 deps =
     pytest
 commands =
-    py.test {posargs}
-
-[testenv:py39]
-basepython = python3.9
-deps =
-    pytest
-commands =
-    py.test {posargs}
-
-[testenv:py310]
-basepython = python3.10
-deps =
-    pytest
-commands =
-    py.test {posargs}
-
-[testenv:py311]
-basepython = python3.11
-deps =
-    pytest
-commands =
-    py.test {posargs}
+    pytest {posargs}
 
 [testenv:black]
 ; "black" is a code formatter, much like gofmt. It requires 3.6 or higher.
 ; Tingle has 3.6 available to it; but feel free to uncomment the line
 ; `ignore_outcome` if it fails. Docs: https://github.com/ambv/black
 ;ignore_outcome = true
-basepython = python3.8
+basepython = python3.9
 deps = black
 skip_install = true
 commands =


### PR DESCRIPTION
## Summary

CI and documentation refresh. This PR is independent of #149 at the git level, but is best reviewed/merged after #149 because its oldest-supported CI job validates the NumPy floor declared there.

- Update GitHub Actions to test Python 3.9–3.13.
- Explicitly pin the Python 3.13 CI leg to `tensorflow==2.20.*`, since TensorFlow 2.20 is currently the only `<2.21` release with CPython 3.13 wheels.
- Add an `oldest-supported` job using Python 3.9, `numpy==1.26.4`, `librosa==0.11.0`, and `tensorflow==2.16.2`.
- Update tox and pyright config from Python 3.8 to 3.9+.
- Refresh README examples to use explicit `Input(shape=...)`, fix channels-last shape comment, and fix `win_length=2018` typo.
- Update ReadTheDocs/Sphinx config for current Sphinx/RTD behavior.
- Reformat release notes as valid rST and add the 0.4.0 entry.
- Fix one docstring typo that broke warning-as-error docs builds.

## Risk / behavior

No runtime behavior changes. The only change under `kapre/` is a docstring typo fix in `time_frequency.py`.

## Tests / verification

- `sphinx -W -b html docs /tmp/kapre-docs-build` passed cleanly.
- Full current-deps test suite: `549 passed, 9 xfailed`.
- Fresh oldest-supported venv:
  - Python 3.9.10
  - TensorFlow 2.16.2
  - NumPy 1.26.4
  - librosa 0.11.0
  - full suite: `549 passed, 9 xfailed`
- Workflow YAML parses successfully.

## Related

- #149 declares the `numpy>=1.26,<3.0` package metadata; this PR adds the CI job that validates that floor.
